### PR TITLE
fix bug in 05_functional_analysis.md

### DIFF
--- a/sessionIII/lessons/05_functional_analysis.md
+++ b/sessionIII/lessons/05_functional_analysis.md
@@ -367,7 +367,7 @@ head(sig_genes)
 ## Remove NA and duplicated values
 sig_genes <- sig_genes[!is.na(names(sig_genes))] 
 
-sig_genes <- sig_genes[!duplicated(sig_genes)]
+sig_genes <- sig_genes[!duplicated(names(sig_genes))]
 
 background_genes <- entrez_results$entrezgene
 


### PR DESCRIPTION
Without this fix, the call to `spia` on line 385 fails (at least for me), with the error

```
de must be a vector of log2 fold changes. The names of de should be included in the refference array!
```
